### PR TITLE
configuration: fix for working configuration

### DIFF
--- a/daemon/iqrf_startup/configuration/config.json
+++ b/daemon/iqrf_startup/configuration/config.json
@@ -1,5 +1,5 @@
 {
-  "Configuration": "v0.8",
+  "Configuration": "v0.0",
   "ConfigurationDir": "configuration",
   "WatchDogTimeoutMilis": 10000,
   "Mode": "operational",


### PR DESCRIPTION
After the upgrade to v0.8.0 the daemon started with core dump
and stopped working.

Fixes: 2292ef4d829334("Version 0.8.0")

Signed-off-by: Peter Tisovčík <xtisov00@stud.fit.vutbr.cz>